### PR TITLE
Add tf_comb utils documentation to html + Add missing dependency pandoc

### DIFF
--- a/docs/API/index.rst
+++ b/docs/API/index.rst
@@ -10,3 +10,4 @@ API reference
    tfcomb.annotation
    tfcomb.distances
    tfcomb.plotting
+   tfcomb.utils

--- a/docs/API/tfcomb.utils.rst
+++ b/docs/API/tfcomb.utils.rst
@@ -1,0 +1,7 @@
+tfcomb.utils module
+======================
+
+.. automodule:: tfcomb.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/required_packages.txt
+++ b/required_packages.txt
@@ -15,3 +15,4 @@ tobias
 uropa
 qnorm
 pip
+pandoc


### PR DESCRIPTION
Closes #24 

Added the util documentation.

I also added the pandoc dependency, because i could not build the documentation locally without this library. Is this okay?