### PR TITLE
Revert "Add tf_comb utils documentation to html + Add missing dependency pandoc"

### DIFF
--- a/docs/API/index.rst
+++ b/docs/API/index.rst
@@ -10,4 +10,3 @@ API reference
    tfcomb.annotation
    tfcomb.distances
    tfcomb.plotting
-   tfcomb.utils

--- a/docs/API/tfcomb.utils.rst
+++ b/docs/API/tfcomb.utils.rst
@@ -1,7 +1,0 @@
-tfcomb.utils module
-======================
-
-.. automodule:: tfcomb.utils
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/required_packages.txt
+++ b/required_packages.txt
@@ -15,4 +15,3 @@ tobias
 uropa
 qnorm
 pip
-pandoc


### PR DESCRIPTION
Halt stop :) 

I would rather not add pandoc to the dependencies, as it is not a dependency of TF-COMB as a package - but rather a dependency to build the docu. Once the project goes public, the docu will be build automatically, and the user will therefore never need pandoc. 

Can you instead create a `required_packages.txt` within [docs](https://github.com/loosolab/TF-COMB/tree/main/docs) including the packages in `README.md` + pandoc? 

The other fixes look good :+1:

(Reverts loosolab/TF-COMB#26)