### PR TITLE
Fixes #55 floating-point error handling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+1.0.4 (in progress)
+-------------------
+- Fix for floating-point error handling (#55)
+
 1.0.3 (23-01-2023)
 ------------------
 - Added pyproject.toml to fix error introduced in 1.0.2 when installing with pip

--- a/tfcomb/__init__.py
+++ b/tfcomb/__init__.py
@@ -1,6 +1,6 @@
 from importlib import import_module
 
-__version__ = "1.0.3"
+__version__ = "1.0.4-b"
 
 #Set classes to be available directly from upper tfcomb, i.e. "from tfcomb import CombObj"
 global_classes = ["tfcomb.objects.CombObj",

--- a/tfcomb/network.py
+++ b/tfcomb/network.py
@@ -61,7 +61,9 @@ def _establish_node_attributes(table, node):
 	
 	for attribute in columns_to_assign:
 		try:
-			p = scipy.stats.chisquare(factorized[node], f_exp=factorized[attribute])[1]
+			# temporary change numpy floating-point error handling
+			with np.errstate(all="raise"):
+				p = scipy.stats.chisquare(factorized[node], f_exp=factorized[attribute])[1]
 		except ValueError: #observed frequencies != expected frequencies
 			p = 0.0 #not correlated
 		except FloatingPointError: #sum of factorized is 0 -> all nan

--- a/tfcomb/objects.py
+++ b/tfcomb/objects.py
@@ -48,7 +48,6 @@ from tfcomb.utils import OneTFBS, Progress, check_type, check_value, check_strin
 from tfcomb.utils import *
 
 
-np.seterr(all='raise') # raise errors for runtimewarnings
 #pd.options.mode.chained_assignment = 'raise' # for debugging
 pd.options.mode.chained_assignment = None
 

--- a/tfcomb/utils.py
+++ b/tfcomb/utils.py
@@ -1981,7 +1981,9 @@ def get_threshold(data, which="upper", percent=0.05, _n_max=10000, verbosity=0, 
 		
 		#Catch any exceptions from fitting
 		try:
-			params = distribution.fit(data_finite)
+			# temporary change numpy floating-point error handling
+			with np.errstate(all="raise"):
+				params = distribution.fit(data_finite)
 		except Exception as e:
 			logger.error("Exception ({0}) occurred while fitting data to '{1}' distribution; skipping this distribution. Error message was: {2} ".format(e.__class__.__name__, distribution.name, e))
 			continue


### PR DESCRIPTION
Instead of changing [numpy floating point error handling](https://numpy.org/doc/stable/reference/generated/numpy.seterr.html) globally on package load use a context manager to temporarily change error handling as needed.